### PR TITLE
Use correct exit codes after tests

### DIFF
--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -27,4 +27,6 @@ if [[ -f "${PWD}/main.go" ]]; then
     PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
 fi
 go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out ./tests
+_EXIT_CODE=$?
 gocov convert .coverage/integration.cover.out | gocov-xml > .coverage/integration.xml
+exit ${_EXIT_CODE}

--- a/commands/sdcli_go_test
+++ b/commands/sdcli_go_test
@@ -11,4 +11,6 @@ if [[ -f "${PWD}/main.go" ]]; then
     PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
 fi
 go test -v -cover -coverpkg="${PKGS}" -coverprofile=.coverage/unit.cover.out ./...
+_EXIT_CODE=$?
 gocov convert .coverage/unit.cover.out | gocov-xml > .coverage/unit.xml
+exit ${_EXIT_CODE}


### PR DESCRIPTION
The commands to generate coverage after failing tests can mask the
non-zero exit code of a test failure. The result may be a green build
with failing tests.