### PR TITLE
Fix golangci compilation errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 sudo: false
 go:
+- 1.12.x
 - 1.11.x
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.12.4 AS BASE
 ENV APT_MAKE_VERSION=4.1-9.1 \
     APT_GCC_VERSION=4:6.3.0-4 \
     APT_GIT_VERSION=1:2.11.0-3+deb9u4 \
-    GOLANGCI_VERSION=v1.12.2
+    GOLANGCI_VERSION=v1.16.0
 
 #########################################
 
@@ -53,7 +53,7 @@ RUN curl -sfL https://deb.nodesource.com/setup_11.x | bash - && \
 FROM JS_DEPS AS PYTHON_DEPS
 
 RUN apt-get install -y python3-pip locales
-RUN pip3 install setuptools cookiecutter
+RUN pip3 install -U setuptools cookiecutter
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN curl -sfL https://deb.nodesource.com/setup_11.x | bash - && \
 
 FROM JS_DEPS AS PYTHON_DEPS
 
-RUN apt-get install -y python3-pip locales
+RUN apt-get install -y locales
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3
 RUN pip3 install -U setuptools cookiecutter
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen


### PR DESCRIPTION
The latest version of the sdcli container throws a warning due to compilation
errors when running the `sdcli go lint` command. Here's an example:

```bash
WARN [runner/megacheck] Can't run megacheck because of compilation errors in packages [github.com/asecurityteam/nexpose-asset-attributor/pkg/domain github.com/asecurityteam/nexpose-asset-attributor github.com/asecurityteam/nexpose-asset-attributor/pkg/assetattributor [github.com/asecurityteam/nexpose-asset-attributor/pkg/assetattributor.test] github.com/asecurityteam/nexpose-asset-attributor/pkg/handlers/v1 [github.com/asecurityteam/nexpose-asset-attributor/pkg/handlers/v1.test]]: pkg/domain/alias.go:1: /usr/local/go/src/internal/bytealg/compare_amd64.s:5:1: illegal character U+0023 '#' and 130 more errors: run `golangci-lint run --no-config --disable-all -E typecheck` to see all errors
```

This appears to be a result of golangci/golangci-lint#433, which was fixed in golangci-lint v1.16.0.