### PR TITLE
integration tests should fail when integration tests exist but fail t…

### DIFF
--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -10,12 +10,12 @@
 
 mkdir -p .coverage
 
-# Check if integration tests are available.
-if ! go test -tags=integration -list . ./tests; then
-    echo "No integration tests found."
-    exit 0
-fi
 INTTESTS=$(go test -tags=integration -list . ./tests)
+FAIL="$(echo "${INTTESTS}" | grep 'FAIL')"
+if [[ ${FAIL} != "" ]]; then
+    echo "A setup or compilation failure occurred."
+    exit 1
+fi
 FOUND="$(echo "${INTTESTS}" | grep 'ok')"
 if [[ ${FOUND} == "" ]]; then
     echo "No integration tests found."


### PR DESCRIPTION
…o compile

I tested with a `tests/storage_test.go` file with an intentional coding error.  Before this PR:

```
test_1 | tests/storage_test.go:543:23: db.GeneratePartitionWithTimestamp undefined (type *storage.DB has no field or method GeneratePartitionWithTimestamp)
test_1 | FAIL github.com/asecurityteam/asset-inventory-api/tests [build failed]
test_1 | No integration tests found.
asset-inventory-api_test_1 exited with code 0
```
Notice `code 0`
After this PR:
```
test_1 | tests/storage_test.go:543:23: db.GeneratePartitionWithTimestamp undefined (type *storage.DB has no field or method GeneratePartitionWithTimestamp)
test_1 | FAIL github.com/asecurityteam/asset-inventory-api/tests [build failed]
test_1 | No integration tests found.
asset-inventory-api_test_1 exited with code 1
```
Notice `code 1`, which is what we want.