### PR TITLE
Adding python linting to SDCLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3
 RUN pip3 install -U setuptools cookiecutter
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen
+RUN pip3 install -U pylint
 
 #########################################
 

--- a/commands/sdcli_python_lint
+++ b/commands/sdcli_python_lint
@@ -2,5 +2,4 @@
 
 #Runs against all python source files stemming from current directory. Config file not required.
 pylint --rcfile .pylintrc
-find . -iname "*.py" | xargs pylint
-
+find . -iname "*.py" -print0 | xargs  -0 pylint

--- a/commands/sdcli_python_lint
+++ b/commands/sdcli_python_lint
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+#Runs against all python source files stemming from current directory. Config file not required.
+pylint --rcfile .pylintrc
+find . -iname "*.py" | xargs pylint
+


### PR DESCRIPTION
Added SDCLI command to run pylint on a repository containing python code. Can be called with: sdcli python lint