### PR TITLE
Sdcli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ sdcli
       coverage # generate a coverage report
   yaml
       lint #runs yamllint against all yamls in current directory
+  version # lists the versions of the installed languages and applications in SDCLI
 ```
 
 <a id="markdown-usage" name="usage"></a>

--- a/commands/sdcli_version
+++ b/commands/sdcli_version
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+#Lists the versions of the various languages and applications installed on SDCLI's image
+
 YELLOW=$(tput setaf 3)
 GREEN=$(tput setaf 2)
 BLUE=$(tput setaf 4)

--- a/commands/sdcli_version
+++ b/commands/sdcli_version
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+YELLOW=$(tput setaf 3)
+GREEN=$(tput setaf 2)
+BLUE=$(tput setaf 4)
+NORMAL=$(tput sgr0)
+
+
+printf "${GREEN}\nGo-related versions\n${NORMAL}"
+
+go version
+golangci-lint --version
+dep version
+
+printf "${BLUE}\nPython-related versions\n${NORMAL}"
+
+python --version
+pylint --version
+pytest --version
+pipenv --version
+coverage --version
+
+printf "${YELLOW}\nEtc\n${NORMAL}"
+
+cookiecutter --version
+
+yamllint --version
+


### PR DESCRIPTION
This command should help debug compatibility issues between sdcli and your projects, since it's sometimes difficult to figure out what version of something our sdcli image is using.