### PR TITLE
Adding templates, new ccextender config file for interactive build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.12.4 AS BASE
 ENV APT_MAKE_VERSION=4.1-9.1 \
     APT_GCC_VERSION=4:6.3.0-4 \
     APT_GIT_VERSION=1:2.11.0-3+deb9u4 \
-    GOLANGCI_VERSION=v1.16.0
+    GOLANGCI_VERSION=v1.16.0 \
+    LANG=C.UTF-8
 
 #########################################
 
@@ -64,7 +65,7 @@ RUN pip3 install pytest
 RUN pip3 install pytest-cov
 RUN pip3 install pipenv
 RUN pip3 install oyaml
-RUN pip3 install --upgrade ccextender
+RUN pip3 install --upgrade git+git://github.com/asecurityteam/ccextender
 RUN pip3 install yamllint
 
 #########################################
@@ -93,6 +94,10 @@ RUN groupadd -r sdcli -g 1000 \
 FROM USER_DEPS
 
 USER sdcli
+
+RUN mkdir -p /home/sdcli/oss-templates/
+
+COPY ./oss-templates/ /home/sdcli/oss-templates/
 
 COPY ./commands/* /usr/bin/
 

--- a/ccextender.yaml
+++ b/ccextender.yaml
@@ -1,44 +1,316 @@
 CCX_Version: 1.1
 standard-context:
-  project_name: "My SecDev OSS Project"
-  project_slug: "my-secdev-oss-project"
-  project_description: "A new SecDev project created with CCExtender"
+  project_name: "New Project"
+  project_slug: "new-project"
   project_namespace: "asecurityteam"
+  project_description: "Description"
+  notification_email: "security-engineering@atlassian.com"
 decisions:
-  docker:
+  language:
     query:
-      prompt: "Is this [1] a dockerized service?"
-    docker:
-      - docker
-  go:
+      prompt: "Will this project use [1] Golang or [2] Python?"
+    golang:
+      - golang-base
+    python:
+      - python-base
+  repo-type:
     query:
-      prompt: "Is this [1] a go service?"
-    go:
-      - go-service
-      - oss
+      prompt: "Will your project be [1] a service or [2] a library?"
+    service:
+      - service
+    library:
+      - library
+  source-python-service:
+    query:
+      prompt: "Will this be [1] an open source or [2] a private source project?"
+      include-if:
+        - python
+        - service
+    python-open:
+      - python-open-service
+    python-private:
+      - python-private-service
+  source-python-library:
+    query:
+      prompt: "Will this be [1] an open source or [2] a private source project?"
+      include-if:
+        - python
+        - library
+    python-open:
+      - python-open-library
+    python-private:
+      - python-private-library
+  source-golang-service:
+    query:
+      prompt: "Will this be [1] an open source or [2] a private source project?"
+      include-if:
+        - golang
+        - service
+    golang-open:
+      - golang-open-service
+    golang-private:
+      - golang-private-service
+  source-golang-library:
+    query:
+      prompt: "Will this be [1] an open source or [2] a private source project?"
+      include-if:
+        - golang
+        - library
+    golang-open:
+      - golang-open-library
+    golang-private:
+      - golang-private-library
+  io:
+    query:
+      prompt: "Will you need [1] both an input stream and output stream, [2] just an input stream, [3] just an output stream, or [0] no message streams?"
+      exclude-if:
+        - golang-open
+        - python-open
+        - library
+    both-io:
+      - input
+      - output
+      - streamer-manager
+    input:
+      - input
+      - streamer-manager
+    output:
+      - output
+      - streamer-manager
 change-packs:
-  docker:
-    template-go-docker:
-  go-service:
-    template-go-layout:
-    template-go-lint:
-  oss:
-    template-oss:
+  golang-base:
+    template-base:
+    template-go-base:
+  python-base:
+    template-base:
+    template-python-base:
+  library:
+  service:
+  golang-open-library:
+    # Currently nothing needed here
+  python-open-library:
+    # Currently nothing needed here
+  golang-private-library:
+    template-go-private-library:
+  python-private-library:
+    # Currently nothing needed here
+  python-open-service:
+    template-makefile:
+        sdcli_lang: python
+    template-python-open-service:
+    template-docker:
+  python-private-service:
+    template-makefile:
+        sdcli_lang: python
+    template-python-private-service:
+  golang-open-service:
+    template-go-open-service:
+    template-docker:
+    template-makefile:
+      sdcli_lang: go
+  golang-private-service:
+    template-go-private-service:
+    template-makefile:
+      sdcli_lang: go
+  input:
+    template-inbound:
+    template-micros:
+      service_descriptor: "
+                           \ benthos-input:\n
+                           \   image: ${BENTHOS_INPUT_ARTIFACT_NAME} #docker.atl-paas.net/sox/asecurityteam/sec-nexpose-asset-producer-benthos-input\n
+                           \   tag: ${ARTIFACT_VERSION}\n
+                           \   deployRestartCount: 3\n
+                           \   ports:\n
+                           \     - \"4195:4195\"\n
+                           \   links:\n
+                           \     - gateway-incoming-private\n
+                           \     - statsd-service-sidecar\n
+                           \ gateway-incoming-private:\n
+                           \   image: ${GATEWAY_INCOMING_PRIVATE_ARTIFACT_NAME} #docker.atl-paas.net/sox/asecurityteam/sec-awsconfig-filterd-gateway-incoming-private\n
+                           \   tag: ${ARTIFACT_VERSION}\n
+                           \   deployRestartCount: 3\n
+                           \   links:\n
+                           \     - app\n
+                           \     - statsd-service-sidecar"
+      docker_compose: "
+                       \ benthos-input:\n
+                       \   build:\n
+                       \     context: .\n
+                       \     dockerfile: benthos-input.Dockerfile\n
+                       \     args:\n
+                       \       REGISTRY: ${REGISTRY}\n
+                       \   image: ${IMAGE}-benthos-input:${TAG}\n
+                       \   environment:\n
+                       \     APP_INPUT_ENDPOINT: \"http://gateway-inbound-private:8082/event\"\n
+                       \     PORTS_BENTHOS_INPUT_STREAMS: \"4195\"\n
+                       \     SQS_CONFIG_QUEUE_URL: \"\"\n
+                       \     SQS_CONFIG_QUEUE_REGION: \"\"\n
+                       \ gateway-incoming-private:\n
+                       \   build:\n
+                       \     context: .\n
+                       \     dockerfile: gateway-incoming-private.Dockerfile\n
+                       \     args:\n
+                       \       REGISTRY: ${REGISTRY}\n
+                       \   image: ${IMAGE}-gateway-incoming-private:${TAG}\n
+                       \   environment:\n
+                       \     PORTS_GATEWAY_INCOMING_PRIVATE: 8082\n
+                       \     APP_ENDPOINT: \"http://app:8081\""
+    template-makefile:
+      makefile_image: "BENTHOS_INPUT_IMAGE_NAME := $(APP_IMAGE_NAME)-benthos-input
+                       \nGATEWAY_INCOMING_PRIVATE_IMAGE_NAME := $(APP_IMAGE_NAME)-gateway-incoming-private"
+      makefile_hack: "MICROS_HACK_ARTIFACT_BENTHOS_INPUT := docker.atl-paas.net$(IMAGE_PATH)/$(BENTHOS_INPUT_IMAGE_NAME)
+                      \nMICROS_HACK_ARTIFACT_GW_INCOMING_PRIVATE := docker.atl-paas.net$(IMAGE_PATH)/$(GATEWAY_INCOMING_PRIVATE_IMAGE_NAME)"
+      makefile_hack_deploy: "
+                             \   BENTHOS_INPUT_ARTIFACT_NAME=$(MICROS_HACK_ARTIFACT_BENTHOS_INPUT) \\\n
+                             \   GW_INCOMING_PRIVATE_ARTIFACT_NAME=$(MICROS_HACK_ARTIFACT_GW_INCOMING_PRIVATE) \\"
+  output:
+    template-outbound:
+    template-micros:
+      service_descriptor: "
+                           \ benthos-output:\n
+                           \   image: ${BENTHOS_OUTPUT_ARTIFACT_NAME} #docker.atl-paas.net/sox/asecurityteam/sec-nexpose-asset-producer-benthos-output\n
+                           \   tag: ${ARTIFACT_VERSION}\n
+                           \   deployRestartCount: 3\n
+                           \   ports:\n
+                           \     - \"4196:4196\"\n
+                           \   links:\n
+                           \     - statsd-service-sidecar\n
+                           \ gateway-outbound:\n
+                           \   image: ${GWO_ARTIFACT_NAME} #docker.atl-paas.net/sox/asecurityteam/sec-ipam-facade-gateway-outbound\n
+                           \   tag: ${ARTIFACT_VERSION}\n
+                           \   deployRestartCount: 3\n
+                           \   links:\n
+                           \     - benthos-output\n
+                           \     - statsd-service-sidecar\n
+                           \   ports:\n
+                           \     - \"8086:8086\""
+      docker_compose: "
+                       \ benthos-output:\n
+                       \   build:\n
+                       \     context: .\n
+                       \     dockerfile: benthos-output.Dockerfile\n
+                       \     args:\n
+                       \       REGISTRY: ${REGISTRY}\n
+                       \   image: ${IMAGE}-benthos-output:${TAG}\n
+                       \   environment:\n
+                       \     PORTS_BENTHOS_OUTPUT: 8086\n
+                       \     SQS_OUTPUT_QUEUE_URL: \"\"\n
+                       \     SQS_OUTPUT_QUEUE_REGION: \"\"\n
+                       \ gateway-outbound:\n
+                       \   build:\n
+                       \     context: .\n
+                       \     dockerfile: gateway-outbound.Dockerfile\n
+                       \   image: ${IMAGE}-gateway-outbound:${TAG}\n
+                       \   environment:\n
+                       \     SERVERFULL_RUNTIME_STATS_OUTPUT: DATADOG\n
+                       \     SERVERFULL_RUNTIME_STATS_DATADOG_PACKETSIZE: 32768\n
+                       \     SERVERFULL_RUNTIME_STATS_DATADOG_TAGS:\n
+                       \     SERVERFULL_RUNTIME_STATS_DATADOG_FLUSHINTERVAL: 10s\n
+                       \     SERVERFULL_RUNTIME_STATS_DATADOG_ADDRESS: statsd:8125\n
+                       \     HTTPPRODUCER_API_HOST: http://benthos-output:4196\n
+                       \   ports:\n
+                       \     - 8082:8082"
+    template-makefile:
+      makefile_image: "BENTHOS_OUTPUT_IMAGE_NAME := $(APP_IMAGE_NAME)-benthos-output
+                      \nGATEWAY_OUTBOUND_IMAGE_NAME := $(APP_IMAGE_NAME)-gateway-outbound"
+      makefile_hack: "MICROS_HACK_ARTIFACT_BENTHOS_OUTPUT := docker.atl-paas.net$(IMAGE_PATH)/$(BENTHOS_OUTPUT_IMAGE_NAME)
+                      \nMICROS_HACK_ARTIFACT_GW_OUTBOUND := docker.atl-paas.net$(IMAGE_PATH)/$(GATEWAY_OUTBOUND_IMAGE_NAME)"
+      makefile_hack_deploy: "
+                             \   BENTHOS_OUTPUT_ARTIFACT_NAME=$(MICROS_HACK_ARTIFACT_BENTHOS_OUTPUT) \\\n
+                             \   GW_OUTBOUND_ARTIFACT_NAME=$(MICROS_HACK_ARTIFACT_GW_OUTBOUND) \\"
+  streamer-manager:
+    template-streamer-manager:
+    template-micros:
+      service_descriptor: "
+                           \ streamer-manager:\n
+                           \   image: ${SM_ARTIFACT_NAME} #docker.atl-paas.net/sox/asecurityteam/sec-awsconfig-transformerd-streamer-manager\n
+                           \   tag: ${ARTIFACT_VERSION}\n
+                           \   links:\n
+                           \     - benthos-input\n
+                           \     - statsd-service-sidecar\n
+                           \   ports:\n
+                           \     - \"8085:8085\"\n
+                           \   deployRestartCount: 3\n
+                           \ lifecycle:\n
+                           \   image: docker.atl-paas.net/sox/asecurityteam/microslifecycle\n
+                           \   tag: latest\n
+                           \   links:\n
+                           \     - streamer-manager\n
+                           \     - statsd-service-sidecar\n
+                           \   deployRestartCount: 3"
+      docker_compose: "
+                       \ streamer-manager:\n
+                       \   build:\n
+                       \     context: .\n
+                       \     dockerfile: streamer-manager.Dockerfile\n
+                       \     args:\n
+                       \       REGISTRY: ${REGISTRY}\n
+                       \   image: ${IMAGE}-streamer-manager:${TAG}\n
+                       \   ports:\n
+                       \     - 8085:8085\n
+                       \   environment:\n
+                       \     STREAMERMANAGER_HTTPSERVER_ADDRESS: \":8085\"\n
+                       \     STREAMERMANAGER_LOGGER_OUTPUT: \"STDOUT\"\n
+                       \     STREAMERMANAGER_STATS_OUTPUT: \"NULL\"\n
+                       \     STREAMERMANAGER_DIRECTORY: \"/configs\"\n
+                       \     STREAMERMANAGER_PATH: \"/lifecycle\"\n
+                       \     STREAMERMANAGER_DESTINATION: \"http://benthos-input:4195\"\n
+                       \ lifecycle:\n
+                       \   image: docker.atl-paas.net/sox/asecurityteam/microslifecycle:latest\n
+                       \   environment:\n
+                       \     MICROSLIFECYCLE_HTTP_NOTIFICATIONS: \"http://streamer-manager:8085/lifecycle\""
+    template-makefile:
+      makefile_image: "STREAMER_MANAGER_IMAGE_NAME := $(APP_IMAGE_NAME)-streamer-manager"
+      makefile_hack: "MICROS_HACK_ARTIFACT_SM := docker.atl-paas.net$(IMAGE_PATH)/$(STREAMER_MANAGER_IMAGE_NAME)"
+      makefile_hack_deploy: "\    SM_ARTIFACT_NAME=$(MICROS_HACK_ARTIFACT_SM) \\"
 locations:
-  home:
-    - https://github.com/asecurityteam/
-  template-go-docker:
-    - $!home$
-    - template-go-docker/
-  template-go-layout:
-    - $!home$
-    - template-go-layout/
-  template-oss:
-    - $!home$
-    - template-oss/
-  template-go-lint:
-    - $!home$
-    - template-go-lint/
-  template-standards:
-    - $!home$
-    - template-oss/
+  github:
+    - /home/sdcli/oss-templates/
+  bitbucket:
+    - /home/sdcli/templates/
+  local-bb:
+    - /Users/aslape/templates/bitbucket-new/
+  local-gh:
+    - /Users/aslape/templates/github-new/
+  template-docker:
+    - $!github$
+    - template-docker
+  template-base:
+    - $!github$
+    - template-base
+  template-go-base:
+    - $!github$
+    - template-go-base
+  template-python-base:
+    - $!github$
+    - template-python-base
+  template-makefile:
+    - $!bitbucket$
+    - template-makefile
+  template-go-private-library:
+    - $!bitbucket$
+    - template-go-library
+  template-python-open-service:
+    - $!github$
+    - template-python-service
+  template-python-private-service:
+    - $!bitbucket$
+    - template-python-service
+  template-go-open-service:
+    - $!github$
+    - template-go-service
+  template-go-private-service:
+    - $!bitbucket$
+    - template-go-service
+  template-inbound:
+    - $!bitbucket$
+    - template-inbound
+  template-outbound:
+    - $!bitbucket$
+    - template-outbound
+  template-micros:
+    - $!bitbucket$
+    - template-micros-ccx
+  template-streamer-manager:
+    - $!bitbucket$
+    - template-streamer-manager

--- a/oss-templates/template-base/cookiecutter.json
+++ b/oss-templates/template-base/cookiecutter.json
@@ -1,0 +1,7 @@
+{
+    "project_name": "New Project",
+    "project_slug": "{{cookiecutter.project_name|lower|replace(' ', '-')|replace('_', '-')}}",
+    "project_description": "",
+    "notification_email": "security-engineering@atlassian.com",
+    "project_namespace": "asecurityteam"
+}

--- a/oss-templates/template-base/{{cookiecutter.project_slug}}/.gitignore
+++ b/oss-templates/template-base/{{cookiecutter.project_slug}}/.gitignore
@@ -1,0 +1,990 @@
+
+# Created by https://www.gitignore.io/api/go,vim,osx,java,node,emacs,linux,xcode,maven,macos,python,windows,eclipse,intellij,jetbrains,virtualenv,sublimetext,visualstudio,visualstudiocode
+
+### Eclipse ###
+
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+### Eclipse Patch ###
+# Eclipse Core
+.project
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Annotation Processing
+.apt_generated
+
+.sts4-cache/
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+### JetBrains ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+### JetBrains Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+
+### Linux ###
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+### Node ###
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Directory for instrumented libs generated by jscoverage/JSCover
+lib-cov
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# nyc test coverage
+.nyc_output
+
+# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+# Bower dependency directory (https://bower.io/)
+bower_components
+
+# node-waf configuration
+.lock-wscript
+
+# Compiled binary addons (https://nodejs.org/api/addons.html)
+build/Release
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+# TypeScript v1 declaration files
+typings/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+
+# next.js build output
+.next
+
+# nuxt.js build output
+.nuxt
+
+# vuepress build output
+.vuepress/dist
+
+# Serverless directories
+.serverless
+
+### OSX ###
+# General
+
+# Icon must end with two \r
+
+# Thumbnails
+
+# Files that might appear in the root of a volume
+
+# Directories potentially created on remote AFP share
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+### Python Patch ###
+.venv/
+
+### Python.VirtualEnv Stack ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+pip-selfcheck.json
+
+### SublimeText ###
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# Workspace files are user-specific
+*.sublime-workspace
+
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+
+# SFTP configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VirtualEnv ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+
+### VisualStudioCode ###
+.vscode/*
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### VisualStudio ###
+## Ignore Visual Studio temporary files, build results, and
+## files generated by popular Visual Studio add-ons.
+##
+## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
+# Visual Studio 2017 auto generated files
+Generated\ Files/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUNIT
+*.VisualState.xml
+TestResult.xml
+
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
+# Benchmark Results
+BenchmarkDotNet.Artifacts/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# StyleCop
+StyleCopReport.xml
+
+# Files built by Visual Studio
+*_i.c
+*_p.c
+*_h.h
+*.ilk
+*.meta
+*.obj
+*.iobj
+*.pch
+*.pdb
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp_proj
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Chutzpah Test files
+_Chutzpah*
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+# Visual Studio Trace Files
+*.e2e
+
+# TFS 2012 Local Workspace
+$tf/
+
+# Guidance Automation Toolkit
+*.gpState
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# JustCode is a .NET coding add-in
+.JustCode
+
+# TeamCity is a build add-in
+_TeamCity*
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# AxoCover is a Code Coverage Tool
+.axoCover/*
+!.axoCover/settings.json
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+nCrunchTemp_*
+
+# MightyMoose
+*.mm.*
+AutoTest.Net/
+
+# Web workbench (sass)
+.sass-cache/
+
+# Installshield output folder
+[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
+
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Including strong name files can present a security risk
+# (https://github.com/github/gitignore/pull/2483#issue-259490424)
+#*.snk
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+*.rptproj.rsuser
+
+# Microsoft Fakes
+FakesAssemblies/
+
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
+# Node.js Tools for Visual Studio
+.ntvs_analysis.dat
+
+# Visual Studio 6 build log
+*.plg
+
+# Visual Studio 6 workspace options file
+*.opt
+
+# Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
+*.vbw
+
+# Visual Studio LightSwitch build output
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.DesktopClient/ModelManifest.xml
+**/*.Server/GeneratedArtifacts
+**/*.Server/ModelManifest.xml
+_Pvt_Extensions
+
+# Paket dependency manager
+.paket/paket.exe
+paket-files/
+
+# FAKE - F# Make
+.fake/
+
+# JetBrains Rider
+.idea/
+*.sln.iml
+
+# CodeRush
+.cr/
+
+# Python Tools for Visual Studio (PTVS)
+*.pyc
+
+# Cake - Uncomment if you are using it
+# tools/**
+# !tools/packages.config
+
+# Tabs Studio
+*.tss
+
+# Telerik's JustMock configuration file
+*.jmconfig
+
+# BizTalk build output
+*.btp.cs
+*.btm.cs
+*.odx.cs
+*.xsd.cs
+
+# OpenCover UI analysis results
+OpenCover/
+
+# Azure Stream Analytics local run output
+ASALocalRun/
+
+# MSBuild Binary and Structured Log
+*.binlog
+
+# NVidia Nsight GPU debugger configuration file
+*.nvuser
+
+# MFractors (Xamarin productivity tool) working folder
+.mfractor/
+
+# Local History for Visual Studio
+.localhistory/
+
+
+# End of https://www.gitignore.io/api/go,vim,osx,java,node,emacs,linux,xcode,maven,macos,python,windows,eclipse,intellij,jetbrains,virtualenv,sublimetext,visualstudio,visualstudiocode

--- a/oss-templates/template-base/{{cookiecutter.project_slug}}/.travis.yml
+++ b/oss-templates/template-base/{{cookiecutter.project_slug}}/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+sudo: false
+go:
+- 1.11.x
+services:
+  - docker
+install:
+  - chmod 777 -R "$(pwd)"
+  - make dep
+script:
+  - make lint
+  - make test
+  - make integration
+  - make coverage
+  - bash <(curl -s https://codecov.io/bash) -f .coverage/combined.cover.out

--- a/oss-templates/template-base/{{cookiecutter.project_slug}}/CODEOWNERS
+++ b/oss-templates/template-base/{{cookiecutter.project_slug}}/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @asecurityteam/secdev

--- a/oss-templates/template-base/{{cookiecutter.project_slug}}/CODE_OF_CONDUCT.md
+++ b/oss-templates/template-base/{{cookiecutter.project_slug}}/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Submitting contributions or comments that you know to violate the intellectual property or privacy rights of others
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer. Complaints will result in a response and be reviewed and investigated in a way that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/oss-templates/template-base/{{cookiecutter.project_slug}}/LICENSE.txt
+++ b/oss-templates/template-base/{{cookiecutter.project_slug}}/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright @ 2019 Atlassian Pty Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/oss-templates/template-base/{{cookiecutter.project_slug}}/README.md
+++ b/oss-templates/template-base/{{cookiecutter.project_slug}}/README.md
@@ -1,0 +1,112 @@
+<a id="markdown-{{cookiecutter.project_name}}" name="{{cookiecutter.project_name}}"></a>
+# {{cookiecutter.project_name}} - {{cookiecutter.project_description}}
+
+<https://github.com/{{cookiecutter.project_namespace}}/{{cookiecutter.project_slug}}>
+
+<!-- TOC -->
+
+- [{{cookiecutter.project_name}} - {{cookiecutter.project_description}}](#{{cookiecutter.project_name}})
+    - [Overview](#overview)
+    - [Quick Start](#quick-start)
+    - [Configuration](#configuration)
+    - [Status](#status)
+    - [Contributing](#contributing)
+        - [Building And Testing](#building-and-testing)
+        - [Quality Gates](#quality-gates)
+        - [License](#license)
+        - [Contributing Agreement](#contributing-agreement)
+
+<!-- /TOC -->
+
+<a id="markdown-overview" name="overview"></a>
+## Overview
+
+<What does this project do?>
+<What does this project _not_ do?>
+<Why did we make this project?>
+<Links to other references or material.>
+
+<a id="markdown-quick-start" name="quick-start"></a>
+## Quick Start
+
+<Hello world style example.>
+
+<a id="markdown-configuration" name="configuration"></a>
+## Configuration
+
+<Details of how to actually work with the project>
+
+<a id="markdown-status" name="status"></a>
+## Status
+
+This project is in incubation which means we are not yet operating this tool in production
+and the interfaces are subject to change.
+
+<a id="markdown-contributing" name="contributing"></a>
+## Contributing
+
+<a id="markdown-building-and-testing" name="building-and-testing"></a>
+### Building And Testing
+
+We publish a docker image called [SDCLI](https://github.com/asecurityteam/sdcli) that
+bundles all of our build dependencies. It is used by the included Makefile to help make
+building and testing a bit easier. The following actions are available through the Makefile:
+
+-   make dep
+
+    Install the project dependencies into a vendor directory
+
+-   make lint
+
+    Run our static analysis suite
+
+-   make test
+
+    Run unit tests and generate a coverage artifact
+
+-   make integration
+
+    Run integration tests and generate a coverage artifact
+
+-   make coverage
+
+    Report the combined coverage for unit and integration tests
+
+-   make build
+
+    Generate a local build of the project (if applicable)
+
+-   make run
+
+    Run a local instance of the project (if applicable)
+
+-   make doc
+
+    Generate the project code documentation and make it viewable
+    locally.
+
+<a id="markdown-quality-gates" name="quality-gates"></a>
+### Quality Gates
+
+Our build process will run the following checks before going green:
+
+-   make lint
+-   make test
+-   make integration
+-   make coverage (combined result must be 85% or above for the project)
+
+Running these locally, will give early indicators of pass/fail.
+
+<a id="markdown-license" name="license"></a>
+### License
+
+This project is licensed under Apache 2.0. See LICENSE.txt for details.
+
+<a id="markdown-contributing-agreement" name="contributing-agreement"></a>
+### Contributing Agreement
+
+Atlassian requires signing a contributor's agreement before we can accept a
+patch. If you are an individual you can fill out the
+[individual CLA](https://na2.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=3f94fbdc-2fbe-46ac-b14c-5d152700ae5d).
+If you are contributing on behalf of your company then please fill out the
+[corporate CLA](https://na2.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=e1c17c66-ca4d-4aab-a953-2c231af4a20b).

--- a/oss-templates/template-docker/cookiecutter.json
+++ b/oss-templates/template-docker/cookiecutter.json
@@ -1,0 +1,6 @@
+{
+    "project_name": "New Project",
+    "project_slug": "{{cookiecutter.project_name|lower|replace(' ', '-')|replace('_', '-')}}",
+    "project_description": "",
+    "project_namespace": "asecurityteam"
+}

--- a/oss-templates/template-docker/{{cookiecutter.project_slug}}/Dockerfile
+++ b/oss-templates/template-docker/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,0 +1,27 @@
+FROM asecurityteam/sdcli:v1 AS BUILDER
+RUN mkdir -p /go/src/github.com/{{cookiecutter.project_namespace}}/{{cookiecutter.project_slug}}
+WORKDIR $GOPATH/src/github.com/{{cookiecutter.project_namespace}}/{{cookiecutter.project_slug}}
+COPY --chown=sdcli:sdcli . .
+RUN sdcli go dep
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o /opt/app main.go
+
+##################################
+
+FROM alpine:latest as CERTS
+RUN apk --no-cache add tzdata zip ca-certificates
+WORKDIR /usr/share/zoneinfo
+# -0 means no compression.  Needed because go's
+# tz loader doesn't handle compressed data.
+RUN zip -r -0 /zoneinfo.zip .
+
+###################################
+
+FROM scratch
+COPY --from=BUILDER /opt/app .
+# the timezone data:
+COPY --from=CERTS /zoneinfo.zip /
+# the tls certificates:
+COPY --from=CERTS /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+ENV ZONEINFO /zoneinfo.zip
+ENTRYPOINT ["/app"]

--- a/oss-templates/template-docker/{{cookiecutter.project_slug}}/api.yaml
+++ b/oss-templates/template-docker/{{cookiecutter.project_slug}}/api.yaml
@@ -1,0 +1,92 @@
+openapi: 3.0.0
+x-runtime:
+  httpserver:
+    address: ":8080"
+  logger:
+    level: "INFO"
+    output: "STDOUT"
+  stats:
+    output: "NULL"
+  signals:
+    installed:
+      - "OS"
+    os:
+      signals:
+        - 2 # SIGINT
+        - 15 # SIGTERM
+  connstate:
+    reportinterval: "5s"
+    hijackedcounter: "http.server.connstate.hijacked"
+    closedcounter: "http.server.connstate.closed"
+    idlegauge: "http.server.connstate.idle.gauge"
+    idlecounter: "http.server.connstate.idle"
+    activegauge: "http.server.connstate.active.gauge"
+    activecounter: "http.server.connstate.active"
+    newgauge: "http.server.connstate.new.gauge"
+    newcounter: "http.server.connstate.new"
+x-transportd:
+  backends:
+    - app
+  app:
+    host: "http://app:8081"
+    pool:
+      ttl: "24h"
+      count: 1
+info:
+  version: 1.0.0
+  title: "{{cookiecutter.project_name}}"
+  description: "{{cookiecutter.project_description}}"
+  contact:
+    name: Security Development
+    email: secdev-external@atlassian.com
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /healthcheck:
+    get:
+      description: "Liveness check."
+      responses:
+        "200":
+          description: "Success."
+      x-transportd:
+        backend: app
+  /{name}:
+    get:
+      description: An API Call.
+      parameters:
+        - name: "name"
+          in: "path"
+          description: "Name of person to greet."
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Greeting'
+      x-transportd:
+        backend: app
+        enabled:
+          - "metrics"
+          - "accesslog"
+          - "requestvalidation"
+          - "responsevalidation"
+          - "lambda"
+        lambda:
+          arn: "name_or_arn"
+          async: false
+          request: '{}'
+          success: '{"status": 200, "bodyPassthrough": true}'
+          error: '{"status": 500, "bodyPassthrough": true}'
+components:
+  schemas:
+    Greeting:
+      type: object
+      properties:
+        greeting:
+          type: string
+          description: The personal greeting.

--- a/oss-templates/template-docker/{{cookiecutter.project_slug}}/docker-compose.yaml
+++ b/oss-templates/template-docker/{{cookiecutter.project_slug}}/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - SERVERFULL_RUNTIME_HTTPSERVER_ADDRESS=:8081
+      - SERVERFULL_RUNTIME_CONNSTATE_REPORTINTERVAL=5s
+      - SERVERFULL_RUNTIME_CONNSTATE_HIJACKEDCOUNTER=http.server.connstate.hijacked
+      - SERVERFULL_RUNTIME_CONNSTATE_CLOSEDCOUNTER=http.server.connstate.closed
+      - SERVERFULL_RUNTIME_CONNSTATE_IDLEGAUGE=http.server.connstate.idle.gauge
+      - SERVERFULL_RUNTIME_CONNSTATE_IDLECOUNTER=http.server.connstate.idle
+      - SERVERFULL_RUNTIME_CONNSTATE_ACTIVEGAUGE=http.server.connstate.active.gauge
+      - SERVERFULL_RUNTIME_CONNSTATE_ACTIVECOUNTER=http.server.connstate.active
+      - SERVERFULL_RUNTIME_CONNSTATE_NEWGAUGE=http.server.connstate.new.gauge
+      - SERVERFULL_RUNTIME_CONNSTATE_NEWCOUNTER=http.server.connstate.new
+      - SERVERFULL_RUNTIME_LOGGER_OUTPUT=STDOUT
+      - SERVERFULL_RUNTIME_LOGGER_LEVEL=INFO
+      - SERVERFULL_RUNTIME_STATS_OUTPUT=NULL
+      - SERVERFULL_RUNTIME_SIGNALS_INSTALLED=OS
+      - SERVERFULL_RUNTIME_SIGNALS_OS_SIGNALS=15 2
+  gateway:
+    build:
+      context: .
+      dockerfile: gateway.Dockerfile
+    ports:
+      - "8080:8080"

--- a/oss-templates/template-docker/{{cookiecutter.project_slug}}/gateway.Dockerfile
+++ b/oss-templates/template-docker/{{cookiecutter.project_slug}}/gateway.Dockerfile
@@ -1,0 +1,3 @@
+FROM asecurityteam/serverfull-gateway
+COPY api.yaml .
+ENV TRANSPORTD_OPENAPI_SPECIFICATION_FILE="api.yaml"

--- a/oss-templates/template-go-base/cookiecutter.json
+++ b/oss-templates/template-go-base/cookiecutter.json
@@ -1,0 +1,6 @@
+{
+    "project_name": "New Project",
+    "project_slug": "{{cookiecutter.project_name|lower|replace(' ', '-')|replace('_', '-')}}",
+    "project_description": "",
+    "project_namespace": "asecurityteam"
+}

--- a/oss-templates/template-go-base/{{cookiecutter.project_slug}}/.golangci.yaml
+++ b/oss-templates/template-go-base/{{cookiecutter.project_slug}}/.golangci.yaml
@@ -1,0 +1,139 @@
+run:
+  deadline: 3m
+  issues-exit-code: 1
+  tests: true
+  skip-dirs:
+    - .coverage
+  #Linter won't check files with build tags (like +build integration) unless you list them under build-tags here.
+  build-tags:
+    - integration
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+linters-settings:
+  errcheck:
+    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: false
+
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    # default is false: such cases aren't reported by default.
+    check-blank: false
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+  golint:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0.8
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: false
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 30
+  dupl:
+    # tokens count to trigger issue, 150 by default
+    threshold: 150
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 3
+  depguard:
+    list-type: blacklist
+    include-go-root: false
+    packages:
+      - github.com/davecgh/go-spew/spew
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    locale: US
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 120
+    # tab width in spaces. Default to 1.
+    tab-width: 1
+  unused:
+    # treat code as a program (not a library) and report unused exported identifiers; default is false.
+    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+  unparam:
+    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+  nakedret:
+    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
+    max-func-lines: 30
+  prealloc:
+    # XXX: we don't recommend using this linter before doing performance profiling.
+    # For most programs usage of prealloc will be a premature optimization.
+
+    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+    # True by default.
+    simple: true
+    range-loops: true # Report preallocation suggestions on range loops, true by default
+    for-loops: true # Report preallocation suggestions on for loops, false by default
+linters:
+  disable-all: true
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - unused
+    - gosimple
+    - structcheck
+    - varcheck
+    - ineffassign
+    - deadcode
+    - golint
+    - gosec
+    - unconvert
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - depguard
+    - misspell
+    - unparam
+    - nakedret
+    - prealloc
+    - gochecknoinits
+issues:
+  exclude-use-default: false
+  exclude:
+    # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+
+    # golint: False positive when tests are defined in package 'test'
+    - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
+
+    # govet: Common false positives
+    - (possible misuse of unsafe.Pointer|should have signature)
+
+    # megacheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
+    - ineffective break statement. Did you mean to break out of the outer loop
+
+    # gas: Too many false-positives on 'unsafe' usage
+    - Use of unsafe calls should be audited
+
+    # gas: Too many false-positives for parametrized shell calls
+    - Subprocess launch(ed with variable|ing should be audited)
+
+    # gas: Duplicated errcheck checks
+    - G104
+
+    # gas: Too many issues in popular repos
+    - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
+
+    # gas: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
+    - Potential file inclusion via variable
+
+  max-per-linter: 50
+  max-same: 3

--- a/oss-templates/template-go-base/{{cookiecutter.project_slug}}/Gopkg.toml
+++ b/oss-templates/template-go-base/{{cookiecutter.project_slug}}/Gopkg.toml
@@ -1,0 +1,34 @@
+# Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
+# for detailed Gopkg.toml documentation.
+[prune]
+  go-tests = true
+  unused-packages = true
+
+[[constraint]]
+  name = "github.com/asecurityteam/settings"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/asecurityteam/serverfull"
+  version = "0.1.0"
+
+[[constraint]]
+  name = "github.com/asecurityteam/serverfull-gateway"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/asecurityteam/runhttp"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/golang/mock"
+  version = "1.2.0"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.3.0"
+
+[[constraint]]
+  name = "github.com/aws/aws-lambda-go"
+  version = "1.8.1"
+

--- a/oss-templates/template-go-service/cookiecutter.json
+++ b/oss-templates/template-go-service/cookiecutter.json
@@ -1,0 +1,6 @@
+{
+    "project_name": "New Project",
+    "project_slug": "{{cookiecutter.project_name|lower|replace(' ', '-')|replace('_', '-')}}",
+    "project_description": "",
+    "project_namespace": "asecurityteam"
+}

--- a/oss-templates/template-go-service/{{cookiecutter.project_slug}}/Makefile
+++ b/oss-templates/template-go-service/{{cookiecutter.project_slug}}/Makefile
@@ -1,0 +1,50 @@
+TAG := $(shell git rev-parse --short HEAD)
+DIR := $(shell pwd -L)
+GOPATH := ${GOPATH}
+ifeq ($(GOPATH),)
+	GOPATH := ${HOME}/go
+endif
+PROJECT_PATH := $(subst $(GOPATH)/src/,,$(DIR))
+
+dep:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        asecurityteam/sdcli:v1 go dep
+
+lint:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        asecurityteam/sdcli:v1 go lint
+
+test:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        asecurityteam/sdcli:v1 go test
+
+integration:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        asecurityteam/sdcli:v1 go integration
+
+coverage:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        asecurityteam/sdcli:v1 go coverage
+
+doc: ;
+
+build-dev: ;
+
+build: ;
+
+run:
+	docker-compose up --build --abort-on-container-exit
+
+deploy-dev: ;
+
+deploy: ;

--- a/oss-templates/template-go-service/{{cookiecutter.project_slug}}/main.go
+++ b/oss-templates/template-go-service/{{cookiecutter.project_slug}}/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/asecurityteam/serverfull"
+	"github.com/asecurityteam/settings"
+)
+
+func main() {
+	ctx := context.Background()
+	handlers := map[string]serverfull.Function{
+		// TODO: Register lambda functions here in the form of
+		// "name_or_arn": lambda.NewHandler(myHandler.Handle)
+	}
+
+	source, err := settings.NewEnvSource(os.Environ())
+	if err != nil {
+		panic(err.Error())
+	}
+	fetcher := &serverfull.StaticFetcher{Functions: handlers}
+	if err := serverfull.Start(ctx, source, fetcher); err != nil {
+		panic(err.Error())
+	}
+}

--- a/oss-templates/template-go-service/{{cookiecutter.project_slug}}/pkg/domain/alias.go
+++ b/oss-templates/template-go-service/{{cookiecutter.project_slug}}/pkg/domain/alias.go
@@ -1,0 +1,17 @@
+package domain
+
+import (
+	"github.com/asecurityteam/runhttp"
+)
+
+// Logger is the project logger interface.
+type Logger = runhttp.Logger
+
+// LogFn is the recommended way to extract a logger from the context.
+type LogFn = runhttp.LogFn
+
+// Stat is the project metrics client interface.
+type Stat = runhttp.Stat
+
+// StatFn is the recommended way to extract a metrics client from the context.
+type StatFn = runhttp.StatFn

--- a/oss-templates/template-go-service/{{cookiecutter.project_slug}}/pkg/domain/doc.go
+++ b/oss-templates/template-go-service/{{cookiecutter.project_slug}}/pkg/domain/doc.go
@@ -1,0 +1,16 @@
+// Package domain is a container of all of the domain types and interfaces
+// that are used across multiple packages within the service.
+//
+// This package is also the container for all domain errors leveraged by the
+// service. Each error here should represent a specific condition that needs to
+// be communicated across interface boundaries.
+//
+// Generally speaking, this package contains no executable code. All elements are
+// expected to be either pure data containers that have no associated methods or
+// interface definitions that have no corresponding implementations in this package.
+// The notable exception to this are the domain error types which are required to
+// define a corresponding Error() method. Because these errors provide executable
+// code they must also have corresponding tests. Only domain error types are allowed
+// to deviate from the "no executable code" rule.
+//
+package domain

--- a/oss-templates/template-go-service/{{cookiecutter.project_slug}}/pkg/handlers/doc.go
+++ b/oss-templates/template-go-service/{{cookiecutter.project_slug}}/pkg/handlers/doc.go
@@ -1,0 +1,3 @@
+// Package handlers contains all top level functionality. Each feature
+// is defined as a lambda function.
+package handlers

--- a/oss-templates/template-go-service/{{cookiecutter.project_slug}}/pkg/handlers/v1/doc.go
+++ b/oss-templates/template-go-service/{{cookiecutter.project_slug}}/pkg/handlers/v1/doc.go
@@ -1,0 +1,3 @@
+// Package v1 is a container for endpoints that are used
+// to power the v1 of the service.
+package v1

--- a/oss-templates/template-go-service/{{cookiecutter.project_slug}}/pkg/logs/doc.go
+++ b/oss-templates/template-go-service/{{cookiecutter.project_slug}}/pkg/logs/doc.go
@@ -1,0 +1,2 @@
+// Package logs contains all structured log events for the service.
+package logs

--- a/oss-templates/template-python-base/cookiecutter.json
+++ b/oss-templates/template-python-base/cookiecutter.json
@@ -1,0 +1,6 @@
+{
+    "project_name": "New Project",
+    "project_slug": "{{cookiecutter.project_name|lower|replace(' ', '-')|replace('_', '-')}}",
+    "project_description": "",
+    "project_namespace": "asecurityteam"
+}

--- a/oss-templates/template-python-base/{{cookiecutter.project_slug}}/.pylintrc
+++ b/oss-templates/template-python-base/{{cookiecutter.project_slug}}/.pylintrc
@@ -1,0 +1,6 @@
+[MESSAGES CONTROL]
+
+disable=
+    no-self-use,
+    import-error,
+    no-else-return

--- a/oss-templates/template-python-base/{{cookiecutter.project_slug}}/Pipfile
+++ b/oss-templates/template-python-base/{{cookiecutter.project_slug}}/Pipfile
@@ -1,0 +1,17 @@
+[packages]
+pytest = "*"
+coverage = "*"
+setuptools = "*"
+pytest-cov = "*"
+oyaml = "*"
+pylint = "*"
+cookiecutter = "*"
+pathlib2 = "*"
+codecov = "*"
+twine = "*"
+
+[requires]
+python_version = "3"
+
+[dev-packages]
+pylint = "*"

--- a/oss-templates/template-python-service/cookiecutter.json
+++ b/oss-templates/template-python-service/cookiecutter.json
@@ -1,0 +1,6 @@
+{
+    "project_name": "New Project",
+    "project_slug": "{{cookiecutter.project_name|lower|replace(' ', '-')|replace('_', '-')}}",
+    "project_description": "",
+    "project_namespace": "asecurityteam"
+}

--- a/oss-templates/template-python-service/{{cookiecutter.project_slug}}/Makefile
+++ b/oss-templates/template-python-service/{{cookiecutter.project_slug}}/Makefile
@@ -1,0 +1,57 @@
+.PHONY : dep lint test integration coverage run
+
+IMAGE_NAME := {{cookiecutter.project_slug}}
+DIR := $(shell pwd -L)
+VERSION := $(shell cat version)
+GOPATH := ${GOPATH}
+ifeq ($(GOPATH),)
+	GOPATH := ${HOME}/go
+endif
+PROJECT_PATH := $(subst $(GOPATH)/src/,,$(DIR))
+REGISTRY := registry.hub.docker.com
+REGISTRY_USER := $(shell whoami)
+REGISTRY_PWD := ""
+IMAGE_PATH := /asecurityteam
+ARTIFACT := $(REGISTRY)$(IMAGE_PATH)/$(IMAGE_NAME)
+
+
+
+dep:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        registry.hub.docker.com/asecurityteam/sdcli:v1 python dep
+
+lint:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        registry.hub.docker.com/asecurityteam/sdcli:v1 python lint
+
+test:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        registry.hub.docker.com/asecurityteam/sdcli:v1 python test
+
+integration: ;
+
+coverage:
+	docker run -ti \
+        --mount src="$(DIR)",target="/go/src/$(PROJECT_PATH)",type="bind" \
+        -w "/go/src/$(PROJECT_PATH)" \
+        registry.hub.docker.com/asecurityteam/sdcli:v1 python coverage
+
+doc: ;
+
+docker-login: ;
+
+build:
+	python3 setup.py bdist_wheel
+
+run: ;
+
+deploy: build
+	python3 -m twine upload dist/*
+
+clean: ;

--- a/oss-templates/template-python-service/{{cookiecutter.project_slug}}/pkg/{{cookiecutter.project_slug}}/test_{{cookiecutter.project_slug}}.py
+++ b/oss-templates/template-python-service/{{cookiecutter.project_slug}}/pkg/{{cookiecutter.project_slug}}/test_{{cookiecutter.project_slug}}.py
@@ -1,0 +1,5 @@
+'''Runs unit tests on {{cookiecutter.project_slug}}'''
+from pkg.{{cookiecutter.project_slug}}.{{cookiecutter.project_slug}} import {{cookiecutter.project_slug}}
+
+def test_init():
+    assert {{cookiecutter.project_slug}}() is True

--- a/oss-templates/template-python-service/{{cookiecutter.project_slug}}/pkg/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}.py
+++ b/oss-templates/template-python-service/{{cookiecutter.project_slug}}/pkg/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}.py
@@ -1,0 +1,13 @@
+
+#!/usr/bin/env python3
+
+class {{cookiecutter.project_slug}}:
+
+    def init(self):
+        '''Constructor for {{cookiecutter.project_slug}}'''
+        return True
+
+
+if __name__ == "__main__":
+
+    {{cookiecutter.project_slug}}()


### PR DESCRIPTION
So there's quite a bit in this PR, as I'm adding the final pieces for our new interactive build system.

The biggest chunk of changes comes from adding new template directories into sdcli (instead of keeping them as individual github repositories). These templates will be used by our interactive build script (sdcli_repo_build + ccextender) to construct our future repositories. The actual contents of these new templates are more or less identical to the template directories we already have, but a few might be altered to work with ccextender. There's a lot to explain about ccextender and how it works with templates, so if you're interested, take a look at the readme: https://github.com/asecurityteam/ccextender, or send me a slack message.

That readme will also help explain the next biggest change, the new ccextender.yaml file. If you're curious about the strange text formatting for some of the yaml values, that's currently the best method I've found to avoid formatting errors when those values are eventually inserted into their respective files. I'm still experimenting with other ways to format those strings, but for now, this is the best option I've found.

Finally, I changed the Dockerfile to install from our github repository, instead of CCExtender's PyPi location, since that will ensure we are always using the newest version. I also added a new environment variable to allow for pip installing from a git repo.