### PR TITLE
Go mod migration

### DIFF
--- a/commands/sdcli_go_dep
+++ b/commands/sdcli_go_dep
@@ -4,4 +4,8 @@
 # NOTE: This will begin to transition to go mod once the go1.12 release
 # is finalized.
 
-dep ensure -v
+if test -f "go.sum"; then
+    GO111MODULE=on go mod vendor
+else
+    dep ensure -v
+fi

--- a/commands/sdcli_go_dep
+++ b/commands/sdcli_go_dep
@@ -4,7 +4,7 @@
 # NOTE: This will begin to transition to go mod once the go1.12 release
 # is finalized.
 
-if test -f "go.sum"; then
+if test -f "go.mod"; then
     GO111MODULE=on go mod vendor
 else
     dep ensure -v


### PR DESCRIPTION
So, to avoid every repo's pipeline breaking while I transfer our projects from dep to go mod, I'm adding a small change to sdcli go dep to temporarily support both options. Once all repositories have been migrated to go mod, I will remove the dep ensure line completely.