### PR TITLE
Adding go mod support to linter, integration, and unit testing tools.

### DIFF
--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -26,7 +26,13 @@ PKGS="$(go list ./... | paste -sd "," -)"
 if [[ -f "${PWD}/main.go" ]]; then
     PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
 fi
-go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out ./tests
+
+if test -f "go.mod"; then
+    GO111MODULE=on go test -mod=vendor -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out ./tests
+else
+    go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out ./tests
+fi
+
 _EXIT_CODE=$?
 gocov convert .coverage/integration.cover.out | gocov-xml > .coverage/integration.xml
 exit ${_EXIT_CODE}

--- a/commands/sdcli_go_lint
+++ b/commands/sdcli_go_lint
@@ -2,4 +2,8 @@
 
 # Run the static analysis suite for go projects.
 
-golangci-lint run --config .golangci.yaml ./... -v
+if test -f "go.mod"; then
+    GO111MODULE=on golangci-lint run --config .golangci.yaml ./... -v
+else
+    golangci-lint run --config .golangci.yaml ./... -v
+fi

--- a/commands/sdcli_go_test
+++ b/commands/sdcli_go_test
@@ -10,7 +10,13 @@ PKGS="$(go list ./... | paste -sd "," -)"
 if [[ -f "${PWD}/main.go" ]]; then
     PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
 fi
-go test -v -cover -coverpkg="${PKGS}" -coverprofile=.coverage/unit.cover.out ./...
+
+if test -f "go.mod"; then
+    GO111MODULE=on go test -mod=vendor -v -cover -coverpkg="${PKGS}" -coverprofile=.coverage/unit.cover.out ./...
+else
+    go test -v -cover -coverpkg="${PKGS}" -coverprofile=.coverage/unit.cover.out ./...
+fi
+
 _EXIT_CODE=$?
 gocov convert .coverage/unit.cover.out | gocov-xml > .coverage/unit.xml
 exit ${_EXIT_CODE}


### PR DESCRIPTION
I've added a new round of changes to our go tooling to support both go mod and dep during the migration. These changes are temporary measure until all our repos are fully converted to go mod. I've added a -mod=vendor to our go test calls, as go test appears to not use the go mod-created vendor directory by default.