### PR TITLE
Add fallback for TERM value

### DIFF
--- a/commands/sdcli_version
+++ b/commands/sdcli_version
@@ -2,7 +2,7 @@
 
 #Lists the versions of the various languages and applications installed on SDCLI's image
 # suppress color coding if TERM was not set
-: ${TERM:=dumb}
+: "${TERM:=dumb}"
 YELLOW=$(tput setaf 3)
 GREEN=$(tput setaf 2)
 CYAN=$(tput setaf 6)

--- a/commands/sdcli_version
+++ b/commands/sdcli_version
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 #Lists the versions of the various languages and applications installed on SDCLI's image
-
+# suppress color coding if TERM was not set
+: ${TERM:=dumb}
 YELLOW=$(tput setaf 3)
 GREEN=$(tput setaf 2)
 CYAN=$(tput setaf 6)

--- a/commands/sdcli_version
+++ b/commands/sdcli_version
@@ -3,6 +3,8 @@
 #Lists the versions of the various languages and applications installed on SDCLI's image
 # suppress color coding if TERM was not set
 : "${TERM:=dumb}"
+export TERM
+
 YELLOW=$(tput setaf 3)
 GREEN=$(tput setaf 2)
 CYAN=$(tput setaf 6)


### PR DESCRIPTION
**Before**
```
$ sdcli version
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
```
Reason -  docker does not pass TERM environment variable on (my ?) mac 

**After**
No error and color codes not rendered TERM is not set or is empty.
