### PR TITLE
Updating go tooling to support go mod vendoring

### DIFF
--- a/commands/sdcli_go_coverage
+++ b/commands/sdcli_go_coverage
@@ -3,6 +3,11 @@
 # Generate a combined coverage report that can be reported to codecov
 # and report combined coverage results to the terminal.
 
+if test -f "go.mod"; then
+    export GOFLAGS='-mod=vendor'
+    export GO111MODULE=on
+fi
+
 mkdir -p .coverage
 gocovmerge .coverage/*.cover.out > .coverage/combined.cover.out
 gocov convert .coverage/combined.cover.out | gocov-xml > .coverage/combined.xml

--- a/commands/sdcli_go_dep
+++ b/commands/sdcli_go_dep
@@ -5,7 +5,9 @@
 # is finalized.
 
 if test -f "go.mod"; then
-    GO111MODULE=on go mod vendor
+    export GOFLAGS='-mod=vendor'
+    export GO111MODULE=on
+    go mod vendor
 else
     dep ensure -v
 fi

--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -8,6 +8,11 @@
 # If no integration tests are found then the command reports
 # that there are no tests and exists successfully.
 
+if test -f "go.mod"; then
+    export GOFLAGS='-mod=vendor'
+    export GO111MODULE=on
+fi
+
 mkdir -p .coverage
 
 INTTESTS=$(go test -tags=integration -list . ./tests)
@@ -27,11 +32,7 @@ if [[ -f "${PWD}/main.go" ]]; then
     PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
 fi
 
-if test -f "go.mod"; then
-    GO111MODULE=on go test -mod=vendor -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out ./tests
-else
-    go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out ./tests
-fi
+go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out ./tests
 
 _EXIT_CODE=$?
 gocov convert .coverage/integration.cover.out | gocov-xml > .coverage/integration.xml

--- a/commands/sdcli_go_lint
+++ b/commands/sdcli_go_lint
@@ -3,7 +3,8 @@
 # Run the static analysis suite for go projects.
 
 if test -f "go.mod"; then
-    GO111MODULE=on golangci-lint run --config .golangci.yaml ./... -v
-else
-    golangci-lint run --config .golangci.yaml ./... -v
+    export GOFLAGS='-mod=vendor'
+    export GO111MODULE=on
 fi
+
+golangci-lint run --config .golangci.yaml ./... -v

--- a/commands/sdcli_go_test
+++ b/commands/sdcli_go_test
@@ -5,17 +5,18 @@
 # the set of covered packages. Library support is enabled by checking the root
 # for a main.go and skipping the removal of the top package if one is not found.
 
+if test -f "go.mod"; then
+    export GOFLAGS='-mod=vendor'
+    export GO111MODULE=on
+fi
+
 mkdir -p .coverage
 PKGS="$(go list ./... | paste -sd "," -)"
 if [[ -f "${PWD}/main.go" ]]; then
     PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
 fi
 
-if test -f "go.mod"; then
-    GO111MODULE=on go test -mod=vendor -v -cover -coverpkg="${PKGS}" -coverprofile=.coverage/unit.cover.out ./...
-else
-    go test -v -cover -coverpkg="${PKGS}" -coverprofile=.coverage/unit.cover.out ./...
-fi
+go test -v -cover -coverpkg="${PKGS}" -coverprofile=.coverage/unit.cover.out ./...
 
 _EXIT_CODE=$?
 gocov convert .coverage/unit.cover.out | gocov-xml > .coverage/unit.xml


### PR DESCRIPTION
So, it looks like my last update wasn't enough to properly implement go mod vendoring support. Luckily, we can set a few environment variables that will ensure that all Golang functions will utilize go mod's vendor directory. Eventually, once we are ready to completely move away from dep, I will set these environment variables permanently in SDCLI's dockerfile.