### PR TITLE
Add `-race` flag to go test commands

### DIFF
--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -32,7 +32,7 @@ if [[ -f "${PWD}/main.go" ]]; then
     PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
 fi
 
-go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out ./tests
+go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out -race ./tests
 
 _EXIT_CODE=$?
 gocov convert .coverage/integration.cover.out | gocov-xml > .coverage/integration.xml

--- a/commands/sdcli_go_test
+++ b/commands/sdcli_go_test
@@ -16,7 +16,7 @@ if [[ -f "${PWD}/main.go" ]]; then
     PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
 fi
 
-go test -v -cover -coverpkg="${PKGS}" -coverprofile=.coverage/unit.cover.out ./...
+go test -v -cover -race -coverpkg="${PKGS}" -coverprofile=.coverage/unit.cover.out ./...
 
 _EXIT_CODE=$?
 gocov convert .coverage/unit.cover.out | gocov-xml > .coverage/unit.xml


### PR DESCRIPTION
Adding the `-race` flag to the go test commands to check for race conditions
in code.