### PR TITLE
Add missing python-slugify dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN pip3 install pytest
 RUN pip3 install pytest-cov
 RUN pip3 install pipenv
 RUN pip3 install oyaml
+RUN pip3 install python-slugify
 RUN pip3 install --upgrade git+git://github.com/asecurityteam/ccextender
 RUN pip3 install yamllint
 


### PR DESCRIPTION
Running `sdcli repo build` currently results in the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.5/dist-packages/pkg/ccextender/ccextender.py", line 12, in <module>
    from slugify import slugify
ImportError: No module named 'slugify'
``` 

The issue is caused by https://github.com/asecurityteam/ccextender/commit/0957ef715c90f61af4dfcfcf0415bb0cb0c0ab0d , we added dependency on slugify w/o reflecting this in setup.py for ccextender or adding the installation to dockerfile