### PR TITLE
I had a scenario where it would have been very nice if SDCLI hadn't h…

### DIFF
--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -16,10 +16,16 @@ fi
 
 mkdir -p .coverage
 
-INTTESTS=$(go test -tags=integration -list . ./tests)
+PKGS="$(go list ./... | paste -sd "," -)"
+if [[ -f "${PWD}/main.go" ]]; then
+    PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
+fi
+
+exec 5>&1
+INTTESTS=$(go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out -race ./tests | tee >(cat - >&5))
 FAIL="$(echo "${INTTESTS}" | grep 'FAIL')"
 if [[ ${FAIL} != "" ]]; then
-    echo "A setup or compilation failure occurred."
+    echo "A setup or compilation failure occurred:"
     echo "${INTTESTS}"
     exit 1
 fi
@@ -28,13 +34,6 @@ if [[ ${FOUND} == "" ]]; then
     echo "No integration tests found."
     exit 0
 fi
-
-PKGS="$(go list ./... | paste -sd "," -)"
-if [[ -f "${PWD}/main.go" ]]; then
-    PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
-fi
-
-go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out -race ./tests
 
 _EXIT_CODE=$?
 gocov convert .coverage/integration.cover.out | gocov-xml > .coverage/integration.xml

--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -20,6 +20,7 @@ INTTESTS=$(go test -tags=integration -list . ./tests)
 FAIL="$(echo "${INTTESTS}" | grep 'FAIL')"
 if [[ ${FAIL} != "" ]]; then
     echo "A setup or compilation failure occurred."
+    echo "${INTTESTS}"
     exit 1
 fi
 FOUND="$(echo "${INTTESTS}" | grep 'ok')"

--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -21,12 +21,12 @@ if [[ -f "${PWD}/main.go" ]]; then
     PKGS="$(go list ./... | sed 1d | paste -sd "," -)"
 fi
 
+# the exec below redirects '5' to stdout so we can simultaneously capture output and print it in the 'go integration' call
 exec 5>&1
 INTTESTS=$(go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out -race ./tests | tee >(cat - >&5))
 FAIL="$(echo "${INTTESTS}" | grep 'FAIL')"
 if [[ ${FAIL} != "" ]]; then
-    echo "A setup or compilation failure occurred:"
-    echo "${INTTESTS}"
+    echo "A setup or compilation failure occurred."
     exit 1
 fi
 FOUND="$(echo "${INTTESTS}" | grep 'ok')"


### PR DESCRIPTION
…idden the output.  :)

I've made my own build of this SDCLI and tested the `go integration` command.  It's all good.  Basically, this PR fixes a problem where tests were run twice, with the first run hiding the output.  I only want the tests run once.  Also the `exec 5>&1` output redirect in this PR is to enable simultaneous capture _and_ real-time stdout of the output emitted by the go command (see the following line in the change).