### PR TITLE
Removed rules that override config file

### DIFF
--- a/commands/sdcli_yaml_lint
+++ b/commands/sdcli_yaml_lint
@@ -6,4 +6,4 @@
 # And a reference for its rules:
 # https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.document_start
 
-yamllint -d "{extends: default, rules: {document-start: disable, quoted-strings: enable}}" .
+yamllint .


### PR DESCRIPTION
Fixing a problem where the -d option was being used which causes rules in the `.yamllint` file to be ignored. Based on the comment https://github.com/asecurityteam/sdcli/compare/remove-default-rule?expand=1#diff-015f890b87f84ecdc5c76284608ccafeR4 this is not how this was supposed to work.

What is more ideal is you allow projects to configure their own .yamllint which once you remove the -d option you can do.