### PR TITLE
updated deb.nodesource to reference nodejs 12 instead of 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.s
 FROM GO_DEPS AS JS_DEPS
 
 # Install NPM
-RUN curl -sfL https://deb.nodesource.com/setup_11.x | bash - && \
+RUN curl -sfL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs
 
 #########################################


### PR DESCRIPTION
Updated Dockerfile to reference NodeJS version 12 instead of 11. 

Linked below is a reference chart to show why the upgrade is necessary.
[Node Version Chart](https://nodejs.org/en/about/releases/)
