### PR TITLE
Change Python linting tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3
 RUN pip3 install -U setuptools cookiecutter
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen
-RUN pip3 install -U pylint
+RUN pip3 install -U flake8
 
 RUN pip3 install coverage
 RUN pip3 install pytest

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sdcli
       build # begins the interactive build process
   python
       dep # install python project dependencies
-      lint # run pylint against the project
+      lint # run flake8 against the project
       test # run unit tests
       coverage # generate a coverage report
   yaml

--- a/commands/sdcli_python_lint
+++ b/commands/sdcli_python_lint
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 #Runs against all python source files stemming from current directory. Config file not required.
-find . -iname "*.py" -print0 | xargs  -0 pylint
+find . -iname "*.py" -print0 | xargs  -0 flake8

--- a/commands/sdcli_version
+++ b/commands/sdcli_version
@@ -20,7 +20,7 @@ dep version
 printf "%s\nPython-related versions\n%s" "${CYAN}" "${NORMAL}"
 
 python --version
-pylint --version
+flake8 --version
 pytest --version
 pipenv --version
 coverage --version


### PR DESCRIPTION
Pylint does not support directory exclusion by path in configuration file. Therefore, we decided to switch Pylint to Flake8, as we need a better python linting tool for our project.