### PR TITLE
remove immediate exit

### DIFF
--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -27,7 +27,7 @@ INTTESTS=$(go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile
 FAIL="$(echo "${INTTESTS}" | grep 'FAIL')"
 if [[ ${FAIL} != "" ]]; then
     echo "A setup or compilation failure occurred."
-    exit 1
+    _EXIT_CODE=1
 fi
 FOUND="$(echo "${INTTESTS}" | grep 'ok')"
 if [[ ${FOUND} == "" ]]; then


### PR DESCRIPTION
Our integration tests immediately exit upon failure and leave us no test result .xml file that bitbucket pipelines can easily parse and we can read.

Trying to read through the build logs is insanely verbose at times, I can rarely tell which of my tests are failing. I think if we avoid immediately exciting on failure and return the test result .xml file we would get a clearer test result.