### PR TITLE
Update golangci to latest upstream version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.13.8 AS BASE
 ENV APT_MAKE_VERSION=4.2.1-1.2 \
     APT_GCC_VERSION=4:8.3.0-1 \
     APT_GIT_VERSION=1:2.20.1-2+deb10u1 \
-    GOLANGCI_VERSION=v1.16.0 \
+    GOLANGCI_VERSION=v1.33.0 \
     LANG=C.UTF-8
 
 #########################################


### PR DESCRIPTION
It looks like the older version we currently use causes issues similar to https://github.com/golangci/golangci-lint/issues/659 , which results in a subset of linter checks not running.