### PR TITLE
[PANG-1286] Update Go base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.2-buster AS BASE
+FROM golang:1.17.7-buster AS BASE
 
 ENV APT_MAKE_VERSION=4.2.1-1.2 \
     APT_GCC_VERSION=4:8.3.0-1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN pip3 install pytest-cov
 RUN pip3 install pipenv
 RUN pip3 install oyaml
 RUN pip3 install python-slugify
-RUN pip3 install --upgrade git+git://github.com/asecurityteam/ccextender
+RUN pip3 install --upgrade git+https://github.com/asecurityteam/ccextender
 RUN pip3 install yamllint
 
 #########################################


### PR DESCRIPTION
Update Go base image from `golang:1.17.2-buster` -> `golang:1.17.7-buster`.

Needed to appease [new requirements from BB Cloud](https://community.atlassian.com/t5/Bitbucket-articles/Changes-to-Bitbucket-API-Requires-Latest-Version-of-Go/ba-p/1975819)

Also, updated the pip install for `ccextender`. 