### PR TITLE
PANG-1287 - Update `golangci-lint` source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN go get github.com/axw/gocov/... && \
     go install github.com/wadey/gocovmerge@latest
 
 # Install lint
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin ${GOLANGCI_VERSION}
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_VERSION}
 
 #########################################
 


### PR DESCRIPTION
Update the source of `golangci-lint` as the old download path no longer exists. 
Used the official docs of the library to make the changes: https://golangci-lint.run/usage/install/#ci-installation
---
Quick demo to show that it worked. Was ran using the below command, with a locally built image with these changes as `sdcli:v1.2.6`
```
sdcli() {
    local cwd="$(pwd)"
    local gopath="${GOPATH}"
    if [[ "${gopath}" == "" ]]; then
        gopath=~/go # default gopath since 1.8
    fi
    local project_path=${cwd#"${gopath}/src/"}
    docker run --rm -v "$(pwd -L):/go/src/${project_path}" \
        -w "/go/src/${project_path}" \
        sdcli:v1.2.6 "$@"
}
```
Running the linter in a repo where the previous version was failing:
```
❯ sdcli go lint
level=info msg="[config_reader] Used config file .golangci.yaml"
level=info msg="[lintersdb] Active 22 linters: [deadcode depguard errcheck gochecknoinits goconst gocyclo gofmt goimports golint gosec gosimple govet ineffassign misspell nakedret prealloc staticcheck structcheck unconvert unparam unused varcheck]"
level=info msg="[loader] Using build tags: [integration]"
level=info msg="[loader] Go packages loading at mode 575 (types_sizes|compiled_files|deps|exports_file|files|imports|name) took 6.837441581s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 16.791195ms"
level=info msg="[linters context/goanalysis] analyzers took 16.487335048s with top 10 stages: buildir: 10.445731798s, buildssa: 794.142715ms, inspect: 580.561059ms, nilness: 425.133134ms, fact_deprecated: 413.504124ms, printf: 403.765541ms, fact_purity: 351.457325ms, unconvert: 300.866345ms, ctrlflow: 261.547937ms, gofmt: 261.072408ms"
level=info msg="[runner] Issues before processing: 28, after processing: 0"
level=info msg="[runner] Processors filtering stat (out/in): cgo: 28/28, filename_unadjuster: 28/28, exclude-rules: 3/3, path_prettifier: 28/28, skip_files: 28/28, identifier_marker: 28/28, exclude: 3/28, nolint: 0/3, skip_dirs: 28/28, autogenerated_exclude: 28/28"
level=info msg="[runner] processing took 6.551595ms with stages: autogenerated_exclude: 4.194578ms, nolint: 866.725µs, exclude: 561.286µs, path_prettifier: 440.653µs, identifier_marker: 374.126µs, skip_dirs: 106.231µs, cgo: 2.608µs, filename_unadjuster: 1.581µs, uniq_by_line: 745ns, max_same_issues: 737ns, skip_files: 330ns, exclude-rules: 306ns, path_shortener: 303ns, source_code: 286ns, diff: 281ns, max_from_linter: 262ns, severity-rules: 179ns, sort_results: 166ns, max_per_file_from_linter: 118ns, path_prefixer: 94ns"
level=info msg="[runner] linters took 4.908991362s with stages: goanalysis_metalinter: 4.902334543s"
level=info msg="File cache stats: 39 entries of total size 97.0KiB"
level=info msg="Memory: 119 samples, avg is 173.1MB, max is 410.0MB"
level=info msg="Execution took 11.77249357s"
```
Tests also ran successfully for (didn't try any beyond these since they aren't used in any Pangolin repo, so I don't have a good _before_ to make sure it works):
* `sdcli go test`
* `sdcli go version`
* `sdcli go coverage`