### PR TITLE
Update to latest Debian stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.17.7-buster AS BASE
+FROM golang:1.17.7-bullseye AS BASE
 
-ENV APT_MAKE_VERSION=4.2.1-1.2 \
-    APT_GCC_VERSION=4:8.3.0-1 \
-    APT_GIT_VERSION=1:2.20.1-2+deb10u3 \
-    GOLANGCI_VERSION=v1.39.0 \
+ENV APT_MAKE_VERSION=4.3-4.1 \
+    APT_GCC_VERSION=4:10.2.1-1 \
+    APT_GIT_VERSION=1:2.30.2-1 \
     LANG=C.UTF-8
 
 #########################################
@@ -81,8 +80,8 @@ RUN groupadd -r sdcli -g 1000 \
 
 FROM user_deps AS docker_cli_deps
 # https://docs.docker.com/engine/install/debian/
-ENV DOCKER_PACKAGE_VERSION=5:20.10.7~3-0~debian-buster
-ENV COMPOSE_PACKAGE_VERSION=1.21.0-3
+ENV DOCKER_PACKAGE_VERSION=5:20.10.6~3-0~debian-bullseye
+ENV COMPOSE_PACKAGE_VERSION=1.25.0-1
 # comes from curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o - > docker-archive-keyring.gpg
 ADD docker-archive-keyring.gpg /usr/share/keyrings/
 ADD docker-apt.list /etc/apt/sources.list.d/docker.list

--- a/docker-apt.list
+++ b/docker-apt.list
@@ -1,1 +1,1 @@
-deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian buster stable
+deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -2,11 +2,11 @@ import pytest
 
 
 @pytest.mark.parametrize("name,version", [
-    ("make", "4.2"),
-    ("gcc", "4:8.3"),
-    ("git", "1:2.20"),
-    ("docker-ce-cli", "5:20.10"),
-    ("docker-compose", "1.21"),
+    ("make", "4.3-4.1"),
+    ("gcc", "4:10.2.1-1"),
+    ("git", "1:2.30.2-1"),
+    ("docker-ce-cli", "5:20.10.6"),
+    ("docker-compose", "1.25"),
 ])
 def test_packages(host, name, version):
     pkg = host.package(name)


### PR DESCRIPTION
The debian oldstable that we are currently using is at EOL, about to come to LTS stage. The quality of LTS  with Debian is not same with what RH and Canonical provide, so we are better off with newer version. Version changes of various utilities match packages available in newer Debian version. https://wiki.debian.org/DebianReleases#Production_Releases related reading.