### PR TITLE
PANG-1518 - Update Docker Compose version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,12 +83,12 @@ RUN groupadd -r sdcli -g 1000 \
 FROM user_deps AS docker_cli_deps
 # https://docs.docker.com/engine/install/debian/
 ENV DOCKER_PACKAGE_VERSION=5:20.10.6~3-0~debian-bullseye
-ENV COMPOSE_PACKAGE_VERSION=1.25.0-1
+ENV COMPOSE_PACKAGE_VERSION=2.11.2~debian-bullseye
 # comes from curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o - > docker-archive-keyring.gpg
 ADD docker-archive-keyring.gpg /usr/share/keyrings/
 ADD docker-apt.list /etc/apt/sources.list.d/docker.list
 # we need cli only, not deamon
-RUN apt-get update && apt-get -y install docker-ce-cli=${DOCKER_PACKAGE_VERSION} docker-compose=${COMPOSE_PACKAGE_VERSION} && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install docker-ce-cli=${DOCKER_PACKAGE_VERSION} docker-compose-plugin=${COMPOSE_PACKAGE_VERSION} && rm -rf /var/lib/apt/lists/*
 
 #########################################
 

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -6,7 +6,7 @@ import pytest
     ("gcc", "4:10.2.1-1"),
     ("git", "1:2.30.2-1"),
     ("docker-ce-cli", "5:20.10.6"),
-    ("docker-compose", "1.25"),
+    ("docker-compose-plugin", "2.11.2"),
 ])
 def test_packages(host, name, version):
     pkg = host.package(name)


### PR DESCRIPTION
Updates the Docker Compose version as the older 1.x versions are no longer supported in the documentation and Nebulae is hard deprecating it. So, it must be updated in order to run Integration Tests with the `sdcli` image.

Followed the guide [here](https://docs.docker.com/engine/install/debian/#install-using-the-repository) for the updated packages, and am using the [latest release](https://docs.docker.com/engine/install/debian/#install-using-the-repository) (`2.11.2`).