### PR TITLE
Runs integration tests from all subdirectories in the tests directory

### DIFF
--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -32,7 +32,7 @@ fi
 
 # the exec below redirects '5' to stdout so we can simultaneously capture output and print it in the 'go integration' call
 exec 5>&1
-INTTESTS=$(go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out -race ./tests -run "${TESTS}" -timeout 15m | tee >(cat - >&5))
+INTTESTS=$(go test -v -tags=integration -cover -coverpkg="${PKGS}" -coverprofile=.coverage/integration.cover.out -race ./tests/... -run "${TESTS}" -timeout 15m | tee >(cat - >&5))
 FAIL="$(echo "${INTTESTS}" | grep 'FAIL')"
 if [[ ${FAIL} != "" ]]; then
     echo "A setup or compilation failure occurred."


### PR DESCRIPTION
# What
Run integration tests from all subdirectories of the `tests` directory.

# Why
Currently the `integration` command which runs integration tests only executes the test files which are directly the children of the `tests` directory. Basically `tests/*.go`

For a directory structure like this
```
tests
└── internal
    └── sqldb
        ├── issue_integration_test.go
        ├── repository_integration_test.go
        └── workspace_integration_test.go
```
the test files are currently not getting executed by the `integration` command.

# How
To run integration tests from all subdirectories in the tests directory the command line argument is being updated from 
`go test ./tests` to 
`go test ./tests/...`.



