### PR TITLE
Fix missing docker-compose command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ ADD docker-archive-keyring.gpg /usr/share/keyrings/
 ADD docker-apt.list /etc/apt/sources.list.d/docker.list
 # we need cli only, not deamon
 RUN apt-get update && apt-get -y install docker-ce-cli=${DOCKER_PACKAGE_VERSION} docker-compose-plugin=${COMPOSE_PACKAGE_VERSION} && rm -rf /var/lib/apt/lists/*
+ADD docker-compose /usr/bin/
 
 #########################################
 

--- a/docker-compose
+++ b/docker-compose
@@ -1,0 +1,2 @@
+#!/bin/sh 
+exec docker compose "$@"

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "name,version,cmd", [
+        ("docker", "20.10", "-v"),
+        ("docker-compose", "2.11", "version")
+    ])
+def test_packages(host, name, version, cmd):
+    c = host.run("{} {}".format(name, cmd))
+    assert c.rc == 0
+    assert version in c.stdout


### PR DESCRIPTION
This adds a shim to emulate `docker-compose` using `docker compose` as we have code relying on existence of -compose and the change that removes it was published as v1. Also adds test for functioning `docker` and `docker-compose`