### PR TITLE
Provide compose plugin and cli tool simultanously, check versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,13 +83,14 @@ RUN groupadd -r sdcli -g 1000 \
 FROM user_deps AS docker_cli_deps
 # https://docs.docker.com/engine/install/debian/
 ENV DOCKER_PACKAGE_VERSION=5:20.10.6~3-0~debian-bullseye
-ENV COMPOSE_PACKAGE_VERSION=2.11.2~debian-bullseye
+ENV COMPOSE_PLUGIN_PACKAGE_VERSION=2.11.2~debian-bullseye
+ENV COMPOSE_PACKAGE_VERSION=1.25.0-1
 # comes from curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o - > docker-archive-keyring.gpg
 ADD docker-archive-keyring.gpg /usr/share/keyrings/
 ADD docker-apt.list /etc/apt/sources.list.d/docker.list
 # we need cli only, not deamon
-RUN apt-get update && apt-get -y install docker-ce-cli=${DOCKER_PACKAGE_VERSION} docker-compose-plugin=${COMPOSE_PACKAGE_VERSION} && rm -rf /var/lib/apt/lists/*
-ADD docker-compose /usr/bin/
+RUN apt-get update && apt-get -y install docker-ce-cli=${DOCKER_PACKAGE_VERSION} docker-compose-plugin=${COMPOSE_PLUGIN_PACKAGE_VERSION} docker-compose=${COMPOSE_PACKAGE_VERSION} \
+    && rm -rf /var/lib/apt/lists/*
 
 #########################################
 

--- a/docker-compose
+++ b/docker-compose
@@ -1,2 +1,0 @@
-#!/bin/sh 
-exec docker compose "$@"

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -4,7 +4,8 @@ import pytest
 @pytest.mark.parametrize(
     "name,version,cmd", [
         ("docker", "20.10", "-v"),
-        ("docker-compose", "2.11", "version")
+        ("docker", "2.11", "compose version"),
+        ("docker-compose", "1.25", "-v")
     ])
 def test_packages(host, name, version, cmd):
     c = host.run("{} {}".format(name, cmd))


### PR DESCRIPTION
Apparently the `docker compose` and `docker-compose` are not 100% compatible. Providing both to allow legacy builds to keep working as is.