### PR TITLE
Add build for arm/v8, for M1 Mac compatability

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7
+          platforms: linux/amd64,linux/arm/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.METAID.outputs.tags }}
           labels: ${{ steps.METAID.outputs.labels }}


### PR DESCRIPTION
M1 Macbooks use the `arm/v8` architecture, so we just need to change the `v7` -> `v8` ([source](https://en.wikipedia.org/wiki/Apple_M1)).

---
Example error:
Trying to run the sdcli on an M1 mac using the `latest` build, which builds as `linux/amd64` and `linux/arm/v7`
<img width="637" alt="image" src="https://user-images.githubusercontent.com/95645866/207980901-c43a9a7a-0f70-4408-af9c-9902aedcafc9.png">
