### PR TITLE
Add build for arm64/v8, for M1 Mac compatability

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.METAID.outputs.tags }}
           labels: ${{ steps.METAID.outputs.labels }}


### PR DESCRIPTION
Arm/v8 is an updated version of the arm architecture, which the M1 Macbook uses. However, the M1 Macbook also uses runs under the 64-bit architecture, so we need to make sure we build the image using 64-bit, rather than the default 32-bit. 

---
Example of error when trying to run the `sdcli` via the `linux/arm/v8` build
![image](https://user-images.githubusercontent.com/95645866/208448191-6432c8d3-1e16-42e6-b5a4-97a7a5352071.png)
