### PR TITLE
Fix docker tagging

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -50,9 +50,9 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
             type=sha
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,9 @@ lint:
 	docker run --rm -i -v "$(DIR):/mnt:ro" koalaman/shellcheck:v0.8.0 commands/*
 
 test:
-	docker build -t local/test/sdcli .
-	docker build -t local/test/sdclitests test
-	docker run -i local/test/sdclitests
 
-integration: ;
+integration:
+	test/run_tests.sh
 
 coverage: ;
 

--- a/commands/sdcli
+++ b/commands/sdcli
@@ -42,6 +42,6 @@ join_by() {
 }
 
 # show help if no sub-command was specified
-test -z "${COMMAND_PATH[@]}" && COMMAND_PATH+=("help")
+test "${#COMMAND_PATH[@]}" -eq 0 && COMMAND_PATH+=("help")
 
 sdcli_"$(join_by "_" "${COMMAND_PATH[@]}")" "${EXTRA_ARGS[@]}"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 docker build -t local/test/sdcli .
-docker build -t local/test/sdclitests -f test.Dockerfile .
+docker build -t local/test/sdclitests test
+docker run -i local/test/sdclitests

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,6 +1,32 @@
 import pytest
 
+
+@pytest.fixture(autouse=True)
+def dir(tmpdir):
+    """Fixture to execute asserts before and after a test is run"""
+    # Setup: fill with any logic you want
+
+    yield # this is where the testing happens
+
+
 def test_help(host):
     c = host.run('/usr/bin/sdcli')
     assert c.rc == 0
     assert 'Available commands' in c.stdout
+
+def test_go_dep(host):
+    c = host.run('/usr/bin/sdcli go dep')
+    assert c.rc != 0
+    assert 'go.mod not found' in c.stderr
+
+def test_python_dep(host):
+    c = host.run('/usr/bin/sdcli python dep')
+    assert c.rc != 0
+    assert 'Usage: pipenv' in c.stderr
+
+
+def test_yaml_lint(host):
+    c = host.run('/usr/bin/sdcli yaml lint')
+    assert c.rc == 0 # no yaml files in test directory, so no error and no output expected
+    assert '' == c.stdout
+    assert '' == c.stderr


### PR DESCRIPTION
Our convention was to use `v` before SemVer, but it was lost during transition to GH actions.