### PR TITLE
GOFLAGS handling and buildvcs fix

### DIFF
--- a/commands/sdcli_go_coverage
+++ b/commands/sdcli_go_coverage
@@ -4,7 +4,7 @@
 # and report combined coverage results to the terminal.
 
 if test -f "go.mod"; then
-    export GOFLAGS='-mod=vendor'
+    export GOFLAGS="-mod=vendor -buildvcs=false ${GOFLAGS:+}"
     export GOPROXY=https://proxy.golang.org
     export GO111MODULE=on
 fi

--- a/commands/sdcli_go_dep
+++ b/commands/sdcli_go_dep
@@ -5,7 +5,8 @@
 # is finalized.
 
 if test -f "go.mod"; then
-    export GOFLAGS='-mod=vendor'
+
+    export GOFLAGS="-mod=vendor -buildvcs=false ${GOFLAGS:+}"
     export GOPROXY=https://proxy.golang.org
     export GO111MODULE=on
     go mod vendor

--- a/commands/sdcli_go_integration
+++ b/commands/sdcli_go_integration
@@ -9,7 +9,7 @@
 # that there are no tests and exists successfully.
 
 if test -f "go.mod"; then
-    export GOFLAGS='-mod=vendor'
+    export GOFLAGS="-mod=vendor -buildvcs=false ${GOFLAGS:+}"
     export GOPROXY=https://proxy.golang.org
     export GO111MODULE=on
 fi

--- a/commands/sdcli_go_lint
+++ b/commands/sdcli_go_lint
@@ -5,7 +5,7 @@ spec="/defaults/.golangci.yaml"
 # Run the static analysis suite for go projects.
 
 if test -f "go.mod"; then
-    export GOFLAGS='-mod=vendor'
+    export GOFLAGS="-mod=vendor -buildvcs=false ${GOFLAGS:+}"
     export GOPROXY=https://proxy.golang.org
     export GO111MODULE=on
 fi

--- a/commands/sdcli_go_test
+++ b/commands/sdcli_go_test
@@ -6,7 +6,7 @@
 # for a main.go and skipping the removal of the top package if one is not found.
 
 if test -f "go.mod"; then
-    export GOFLAGS='-mod=vendor'
+    export GOFLAGS="-mod=vendor -buildvcs=false ${GOFLAGS:+}"
     export GOPROXY=https://proxy.golang.org
     export GO111MODULE=on
 fi


### PR DESCRIPTION
* Add -buildvcs=false to default GOFLAGS as there is a regression ("feature") in golang starting with https://tip.golang.org/doc/go1.18 that is causing build/test steps to fail when VCS commands do not run Example: https://app.travis-ci.com/github/asecurityteam/transportd/builds/266710818#L290
* Changle handling of GOFLAGS in sdcli so that we can pass additional flags in environment, and those would be appended. This way we can override exiting parameters or add new w/o rebuilding images