### PR TITLE
Update docker build and push action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,6 +26,9 @@ jobs:
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55
+
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,7 +55,7 @@ jobs:
             type=semver,pattern=v{{major}}
             type=sha
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8


### PR DESCRIPTION
Trying to fix https://github.com/asecurityteam/sdcli/actions/runs/13272660135/job/37114071727#step:7:983
Apparently, the qemu setup step from docker uses a container with `:latest` tag and there is a regression 😨 .
Forcing it to the last known good hash of the image from https://github.com/asecurityteam/sdcli/actions/runs/13272580346/job/37055266682#step:3:109  seems to help