### PR TITLE
update golang upstream image to 1.26.2 to address runtime vulnerabilities

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+              max-parallelism = 1
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-trixie AS base
+FROM golang:1.26.2 AS base
 
 ENV LANG=en_US.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ADD defaults/.golangci.yaml /defaults/.golangci.yaml
 WORKDIR /go-tools
 # golangci-lint specifically asks to not use go tool and similar...
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
-RUN go mod download && grep _ tools.go | grep -v golangci-lint | awk -F'"' '{print $2}' | xargs -tI % go install % && cd .. && rm /go-tools/* && rmdir /go-tools
+RUN GOFLAGS="-p=1" GOMAXPROCS=1 go mod download && grep _ tools.go | grep -v golangci-lint | awk -F'"' '{print $2}' | xargs -tI % env GOFLAGS="-p=1" GOMAXPROCS=1 go install % && cd .. && rm /go-tools/* && rmdir /go-tools
 WORKDIR /
 
 


### PR DESCRIPTION
This will get tagged 3.2.0 and latest once merged.