### PR TITLE
use newer golangcilint built with golang 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ADD golang/* /go-tools/
 ADD defaults/.golangci.yaml /defaults/.golangci.yaml
 WORKDIR /go-tools
 # golangci-lint specifically asks to not use go tool and similar...
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.1
 RUN GOFLAGS="-p=1" GOMAXPROCS=1 go mod download && grep _ tools.go | grep -v golangci-lint | awk -F'"' '{print $2}' | xargs -tI % env GOFLAGS="-p=1" GOMAXPROCS=1 go install % && cd .. && rm /go-tools/* && rmdir /go-tools
 WORKDIR /
 


### PR DESCRIPTION
The previous one was throwing version mismatch errors with go 1.26
This will be v3.3.0 as there are potential breaking changes in linter behavior.